### PR TITLE
Fixes typo in the notebook

### DIFF
--- a/UnsupervisedAnalysis.ipynb
+++ b/UnsupervisedAnalysis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Unsupservised Analysis of Days of Week\n",
+    "# Unsupervised Analysis of Days of Week\n",
     "\n",
     "Treating crossings each day as features to learn about the relationships between various days."
    ]


### PR DESCRIPTION
This is a fix for a typo on the title of the notebook that I noticed on youtube